### PR TITLE
chore: Update Planning component with default simulation date

### DIFF
--- a/app/(components)/Planning/index.tsx
+++ b/app/(components)/Planning/index.tsx
@@ -48,7 +48,7 @@ const Planning = ({
   const [demandFile, setDemandFile] = useState<File | File[] | null>(null);
   const [buttonDisabled, setButtonDisabled] = useState(false);
   const [simulationDate, setSimulationDate] = useState<Date | undefined>(
-    undefined
+    new Date()
   );
   const [additionalData, setAdditionalData] = useState({
     backlog_priority: false,


### PR DESCRIPTION
The Planning component has been updated to set the default simulation date to the current date. This change ensures that the simulation date is always initialized when the component is rendered.